### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,9 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install nix
-        uses: cachix/install-nix-action@v30
+        uses: cachix/install-nix-action@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72 # v30
         with:
           nix_path: "${{ matrix.nixPath }}"
           extra_nix_config: |
@@ -51,7 +51,7 @@ jobs:
       - name: Show nixpkgs version
         run: nix-instantiate --eval -E '(import <nixpkgs> {}).lib.version'
       - name: Setup cachix
-        uses: cachix/cachix-action@v15
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
         # Don't replace <YOUR_CACHIX_NAME> here!
         if: ${{ matrix.cachixName != '<YOUR_CACHIX_NAME>' }}
         with:


### PR DESCRIPTION
## Summary

Pin all unpinned actions to their full commit SHAs to prevent supply-chain attacks via mutable tags.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` (`# v4`) |
| `cachix/install-nix-action` | `@v30` | `@08dcb3a5e62fa31e2da3d490afc4176ef55ecd72` (`# v30`) |
| `cachix/cachix-action` | `@v15` | `@ad2ddac53f961de1989924296a1f236fcfbaa4fc` (`# v15`) |

No behavioral changes — all actions are pinned to the exact versions already in use.